### PR TITLE
feature/travis php 5.5 no cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,7 @@ after_script:
 
 # Run main commands
 script:
-  - echo TRAVIS_PHP_VERSION
-  - if [ $TRAVIS_PHP_VERSION = "5.5.38" ]; then composer test-5.5; else composer test; fi
+  - if [ $TRAVIS_PHP_VERSION = "5.5" ]; then composer test-5.5; else composer test; fi
 
 # Cache folder, you can delete cache from Travis CI web interface
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ after_script:
 
 # Run main commands
 script:
-  - echo $TRAVIS_PHP_VERSION
+  - echo TRAVIS_PHP_VERSION
   - if [ $TRAVIS_PHP_VERSION = "5.5.38" ]; then composer test-5.5; else composer test; fi
 
 # Cache folder, you can delete cache from Travis CI web interface

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ php:
   - 7.1
   - 7.2
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: 5.5
-
 # Setting up redis server
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ sudo: false
 # Install packages those will be required during build
 install:
   - composer install --no-interaction
+  - if [ $TRAVIS_PHP_VERSION != "5.5" ]; then composer require cache/predis-adapter --dev; fi
 
 # Prepare test environment
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,15 @@ before_script:
 
 # To manage coverage for CodeClimate
 after_script:
-- mv tests/_output/coverage.xml clover.xml
-- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - mv tests/_output/coverage.xml clover.xml
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+# $TRAVIS_PHP_VERSION
 
 # Run main commands
 script:
-  - composer test
+  - echo $TRAVIS_PHP_VERSION
+  - if [ $TRAVIS_PHP_VERSION = "5.5.38" ]; then composer test-5.5; else composer test; fi
 
 # Cache folder, you can delete cache from Travis CI web interface
 cache:

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
   },
   "scripts": {
     "test": "./vendor/bin/codecept run unit --coverage --coverage-xml --no-interaction",
-    "test-5.5": "./vendor/bin/codecept run unit --coverage --coverage-xml --no-interaction  -g client -g parser"
+    "test-5.5": "./vendor/bin/codecept run unit --no-interaction  -g client -g parser"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
   },
   "require-dev": {
     "codeception/codeception": "^2.4",
-    "vlucas/phpdotenv": "^2.4",
-    "cache/predis-adapter": "^1.0"
+    "vlucas/phpdotenv": "^2.4"
   },
   "scripts": {
-    "test": "./vendor/bin/codecept run unit --coverage --coverage-xml --no-interaction"
+    "test": "./vendor/bin/codecept run unit --coverage --coverage-xml --no-interaction",
+    "test-5.5": "./vendor/bin/codecept run unit --coverage --coverage-xml --no-interaction  -g client -g parser"
   }
 }

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -3,6 +3,10 @@
 # Suite for unit or integration tests.
 
 actor: UnitTester
+groups:
+  client: ['tests/unit/Client/ClientTest.php', 'tests/unit/Client/Endpoint/Languages.php', 'tests/unit/Client/Endpoint/StatusTest.php', 'tests/unit/Client/Endpoint/TranslateTest.php']
+  client.cache: ['tests/unit/Client/ClientCachingTest.php', 'tests/unit/Client/CachedTranslateTest.php']
+  parser: ['tests/unit/Parser/ParserTest.php', 'tests/unit/Parser/Check/Dom/MetaContentTest.php']
 modules:
     enabled:
         - Asserts

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -81,16 +81,4 @@ class ClientTest extends \Codeception\Test\Unit
         $response = $this->client->makeRequest('GET', '/status', [], false);
         $this->assertTrue($response->getStatusCode() === 200);
     }
-
-    public function testMakeRequestThrowGuzzleException()
-    {
-        if (version_compare(phpversion(), '5.5', '>')) {
-            $this->expectException(\Weglot\Client\Api\Exception\ApiError::class);
-
-            $this->client->setOptions([
-                'host'  => 'https://foo.bar.baz',
-            ]);
-            $response = $this->client->makeRequest('GET', '/status', []);
-        }
-    }
 }

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -84,11 +84,13 @@ class ClientTest extends \Codeception\Test\Unit
 
     public function testMakeRequestThrowGuzzleException()
     {
-        $this->expectException(\Weglot\Client\Api\Exception\ApiError::class);
+        if (version_compare(phpversion(), '5.5', '>')) {
+            $this->expectException(\Weglot\Client\Api\Exception\ApiError::class);
 
-        $this->client->setOptions([
-            'host'  => 'https://foo.bar.baz',
-        ]);
-        $response = $this->client->makeRequest('GET', '/status', []);
+            $this->client->setOptions([
+                'host'  => 'https://foo.bar.baz',
+            ]);
+            $response = $this->client->makeRequest('GET', '/status', []);
+        }
     }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! If this is your first time, read our contributor guidelines -->

**What this PR does / why we need it**:
Travis CI run always fails for PHP 5.5 cause it doesn't support caching. So let's remove caching by default and run it only on purpose.

**Which issue(s) this PR fixes**:
<!-- We suggest to use issue number with tag: #XX -->
- Fixes #22 

**Special notes for your reviewer**:
This is a bit ugly, but working 😵 