### PR TITLE
Avoid crash when every word pair hits in the cache

### DIFF
--- a/src/Client/Endpoint/Translate.php
+++ b/src/Client/Endpoint/Translate.php
@@ -175,14 +175,20 @@ class Translate extends Endpoint
             $asArray['words'] = $beforeRequest[0];
         }
 
-        list($rawBody, $httpStatusCode, $httpHeader) = $this->request($asArray, false);
-        if ($httpStatusCode !== 200) {
-            throw new ApiError($rawBody, $asArray);
-        }
+        if (empty($asArray['words'])) {
+            if ($this->getCache()->enabled()) {
+                $response = $this->afterRequest($asArray, $beforeRequest);
+            }
+        } else {
+            list($rawBody, $httpStatusCode) = $this->request($asArray, false);
+            if ($httpStatusCode !== 200) {
+                throw new ApiError($rawBody, $asArray);
+            }
 
-        $response = json_decode($rawBody, true);
-        if ($this->getCache()->enabled()) {
-            $response = $this->afterRequest($response, $beforeRequest);
+            $response = json_decode($rawBody, true);
+            if ($this->getCache()->enabled()) {
+                $response = $this->afterRequest($response, $beforeRequest);
+            }
         }
 
         $factory = new TranslateFactory($response);


### PR DESCRIPTION
If you pass the same information to the API after enabling caching using a PSR-6 cache, you'll get the following crash:

`Weglot\Client\Api\Exception\ApiError · words: This value should not be blank.`

This adds detection for this zero-words-to-translate case and skips the API call completely, both preventing the crash and significantly speeding up the API.