### PR TITLE
Detect AhrefsBot as BotType::GOOGLE rather than BotType::OTHER

### DIFF
--- a/src/Util/Server.php
+++ b/src/Util/Server.php
@@ -41,6 +41,7 @@ class Server
         $checkBotGoogle = (Text::contains($userAgent, 'Google') ||
                             Text::contains($userAgent, 'facebook') ||
                             Text::contains($userAgent, 'wprocketbot') ||
+                            Text::contains($userAgent, 'AhrefsBot') ||
                             Text::contains($userAgent, 'SemrushBot'));
 
         if ($userAgent !== null && !$checkBotAgent) {


### PR DESCRIPTION
Treat Ahrefs the same as Facebook, WP Rocket and SEMrush

This simply adds 'AhrefsBot' to the list of bots detected as Google rather than Other.
