### PR TITLE
Fix E_NOTICE undefined index

### DIFF
--- a/src/Util/Url.php
+++ b/src/Util/Url.php
@@ -133,7 +133,9 @@ class Url
 
         if ($this->translate->checkIfAvailable($code)) {
             $all = $this->currentRequestAllUrls();
-            $url = $all[$code];
+            if (isset($all[$code])) {
+                $url = $all[$code];
+            }
         }
 
         return $url;


### PR DESCRIPTION
This notice was happening once again when running WP-CLI tasks.

**What this PR does / why we need it**:

In some cases `checkIfAvailable($code)` may return true while the array returned from `currentRequestAllUrls()` does not actually contain the key `$code`, causing the `$all[$code]` on the next line to fail and throw a notice. This appears to happen in WP-CLI, but may also happen elsewhere. This just fixes it with an extra 

Another approach you might consider is another early return:

```php
if (defined('WP_CLI')) {
    return false;
}
```

**Special notes for your reviewer**:

**How you would summarize your PR ? (for changelog)**: Fix undefined index Notice when running via WP-CLI (and possibly elsewhere)
